### PR TITLE
feat(workflows): añadir flujo de trabajo para publicar en PYPI

### DIFF
--- a/.github/workflows/release-library-pypi.yml
+++ b/.github/workflows/release-library-pypi.yml
@@ -1,0 +1,65 @@
+name: Generate Python Library & Publish on PYPI
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy-patch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip build
+          pip install -r requirements.txt
+
+      - name: Get next version
+        id: generate_release_tag
+        uses: phish108/autotag-action@1.1.53
+        with:
+          github-token: ${{ secrets.TOKEN_GITHUB}}
+          with-v: "true"
+          bump: patch
+
+      - name: Update version in setup.py
+        run: sed -i 's/VERSION = "0.0.0"/VERSION = "${{ steps.generate_release_tag.outputs.new-tag }}"/g' setup.py
+
+      - name: Build package
+        run: python -m build
+
+      - name: Check Output Parameters
+        run: |
+          echo "Got tag name ${{ steps.generate_release_tag.outputs.new-tag }}"
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.TOKEN_GITHUB }}
+        with:
+          tag_name: ${{ steps.generate_release_tag.outputs.new-tag }}
+          release_name: Release ${{ steps.generate_release_tag.outputs.new-tag }}
+
+      - name: Upload Release Assets
+        id: upload-release-assets
+        uses: dwenegar/upload-release-assets@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.TOKEN_GITHUB }}
+        with:
+          release_id: ${{ steps.create_release.outputs.id }}
+          assets_path: dist/
+
+      - name: Publish package PYPI
+        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Se ha creado un nuevo archivo de flujo de trabajo de GitHub Actions para automatizar la generación y publicación de la biblioteca de Python en PYPI cada vez que se haga push a la rama master. Se incluyen pasos para verificar el código, instalar dependencias, generar un nuevo tag de versión, construir el paquete y publicarlo.